### PR TITLE
Add 3xx codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Newspack 404 Cache
 
 Removes headers which prevent caching 404 responses.
+
+An optional constant can be provided in `wp-config.php` and contain an array of one or multiple custom 3xx response codes, e.g.
+```
+define( 'NEWSPACK_EDGE_CACHE_CUSTOM_REDIRECT_CODES', [ 301, 302 ] );
+```
+If these additional 3xx codes are provided, cache preventing headers will be removed from those requests as well.

--- a/newspack-404-cache.php
+++ b/newspack-404-cache.php
@@ -1,22 +1,34 @@
 <?php
 /**
  * Plugin Name:       Newspack 404 Cache
- * Description:       Removes headers which prevent caching 404 responses.
- * Version:           0.0.1
+ * Description:       Removes headers which prevent caching 404 or custom 3xx redirect responses.
+ * Version:           0.0.2
  * Author:            Automattic
  * Author URI:        https://automattic.com
  * Text Domain:       newspack-404-cache
  * Domain Path:       /languages
  */
 
+// 404.
 add_filter(
-        'nocache_headers',
-        function( $headers ) {
-                if ( is_404() ) {
-                        unset( $headers['Cache-Control'] );
-                        unset( $headers['Expires'] );
-                }
-                return $headers;
+    'nocache_headers',
+    function( $headers ) {
+        if ( is_404() ) {
+            unset( $headers['Cache-Control'] );
+            unset( $headers['Expires'] );
         }
+        return $headers;
+    }
 );
 
+// 3xx.
+if ( defined( 'NEWSPACK_EDGE_CACHE_CUSTOM_REDIRECT_CODES' ) ) {
+    add_filter( 'wp_redirect_status', function ( $status, $location ) {
+        $codes = defined( 'NEWSPACK_EDGE_CACHE_CUSTOM_REDIRECT_CODES' ) ? NEWSPACK_EDGE_CACHE_CUSTOM_REDIRECT_CODES : [];
+        if ( in_array( $status, $codes ) ) {
+            header_remove( 'Cache-Control' );
+            header_remove( 'Expires' );
+        }
+        return $status;
+    }, 10, 2 );
+}


### PR DESCRIPTION
As updated README says, the optional constant can be defined which will additionally remove headers which prevent caching for 3xx redirection statuses, e.g.
```
define( 'NEWSPACK_EDGE_CACHE_CUSTOM_REDIRECT_CODES', [ 301, 302 ] );
```